### PR TITLE
예적금 계좌 정보 가져오기 기능을 구현

### DIFF
--- a/src/main/java/com/ssafy/tott/api/seoul/module/HouseAPI.java
+++ b/src/main/java/com/ssafy/tott/api/seoul/module/HouseAPI.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 @Component
 public class HouseAPI {
     @Value("${seouldata.tbLnOpendataRentV.key}")
-    private final String key;
+    private String key;
 
     public RentApiModel fetchAPI(int start, int end) throws IOException {
         StringBuilder urlBuilder = new StringBuilder("http://openapi.seoul.go.kr:8088");

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -60,9 +60,8 @@ public class ShinhanBankAPI {
     public ShinhanBankAPIResponse searchSavingAccountAPI(String account) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key,
-                SearchSavingAccountRequestShinhanBankDataBody.of(account)
+                SearchSavingAccountRequestShinhanBankDataBody.from(account)
         );
-        logging(request.getShinhanBankDataBody());
         String json = convertRequestToJson(request);
         ShinhanBankAPIResponse response = searchAmountAPI.fetchAPI(json);
         validate(response);

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -9,6 +9,8 @@ import com.ssafy.tott.api.exception.APIException;
 import com.ssafy.tott.api.shinhan.dto.ShinhanBankDataBody;
 import com.ssafy.tott.api.shinhan.dto.request.ShinhanBankAPIRequest;
 import com.ssafy.tott.api.shinhan.dto.response.ShinhanBankAPIResponse;
+import com.ssafy.tott.api.shinhan.service.searchamount.ShinhanBankSearchAmountAPI;
+import com.ssafy.tott.api.shinhan.service.searchamount.dto.request.SearchSavingAccountRequestShinhanBankDataBody;
 import com.ssafy.tott.api.shinhan.service.searchname.ShinhanBankSearchNameAPI;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.request.SearchNameRequestShinhanBankDataBody;
 import com.ssafy.tott.api.shinhan.service.transfer1.ShinhanBankTransfer1API;
@@ -27,6 +29,7 @@ public class ShinhanBankAPI {
     private final ObjectMapperConfig objectMapperConfig;
     private final ShinhanBankTransfer1API transfer1API;
     private final ShinhanBankSearchNameAPI searchNameAPI;
+    private final ShinhanBankSearchAmountAPI searchAmountAPI;
 
     @Value("${SHINHAN_BANK.API.KEY}")
     private String key;
@@ -50,6 +53,18 @@ public class ShinhanBankAPI {
         logging(request.getShinhanBankDataBody());
         String json = convertRequestToJson(request);
         ShinhanBankAPIResponse response = transfer1API.fetchAPI(json);
+        validate(response);
+        return response;
+    }
+
+    public ShinhanBankAPIResponse searchSavingAccountAPI(String account) {
+        ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
+                key,
+                SearchSavingAccountRequestShinhanBankDataBody.of(account)
+        );
+        logging(request.getShinhanBankDataBody());
+        String json = convertRequestToJson(request);
+        ShinhanBankAPIResponse response = searchAmountAPI.fetchAPI(json);
         validate(response);
         return response;
     }

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/ShinhanBankSearchAmountAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/ShinhanBankSearchAmountAPI.java
@@ -1,0 +1,30 @@
+package com.ssafy.tott.api.shinhan.service.searchamount;
+
+import com.ssafy.tott.api.APICore;
+import com.ssafy.tott.api.shinhan.dto.response.ShinhanBankAPIResponse;
+import com.ssafy.tott.api.shinhan.factory.ShinhanBankWebClientFactory;
+import com.ssafy.tott.api.shinhan.service.searchamount.dto.response.ShinhanBankSearchSavingAccountResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Component
+public class ShinhanBankSearchAmountAPI implements APICore {
+    private final ShinhanBankWebClientFactory shinhanBankWebClientFactory;
+
+    @Value("${SHINHAN_BANK.API.URI.SEARCH_AMOUNT}")
+    private String uri;
+
+    @Override
+    public ShinhanBankAPIResponse fetchAPI(String json) {
+        WebClient webClient = shinhanBankWebClientFactory.createWebClientWithURI(uri);
+        return webClient.post()
+                .bodyValue(json)
+                .retrieve()
+                .bodyToMono(ShinhanBankSearchSavingAccountResponse.class)
+                .block();
+    }
+
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/request/SearchSavingAccountRequestShinhanBankDataBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/request/SearchSavingAccountRequestShinhanBankDataBody.java
@@ -1,0 +1,22 @@
+package com.ssafy.tott.api.shinhan.service.searchamount.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.tott.api.shinhan.dto.ShinhanBankDataBody;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SearchSavingAccountRequestShinhanBankDataBody extends ShinhanBankDataBody {
+    @JsonProperty("계좌번호")
+    private String account;
+
+    private SearchSavingAccountRequestShinhanBankDataBody(String account) {
+        this.account = account;
+    }
+
+    public static SearchSavingAccountRequestShinhanBankDataBody of(String accountNumber) {
+        return new SearchSavingAccountRequestShinhanBankDataBody(accountNumber);
+    }
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/request/SearchSavingAccountRequestShinhanBankDataBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/request/SearchSavingAccountRequestShinhanBankDataBody.java
@@ -16,7 +16,7 @@ public class SearchSavingAccountRequestShinhanBankDataBody extends ShinhanBankDa
         this.account = account;
     }
 
-    public static SearchSavingAccountRequestShinhanBankDataBody of(String accountNumber) {
-        return new SearchSavingAccountRequestShinhanBankDataBody(accountNumber);
+    public static SearchSavingAccountRequestShinhanBankDataBody from(String account) {
+        return new SearchSavingAccountRequestShinhanBankDataBody(account);
     }
 }

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/response/ShinhanBankSearchSavingAccountResponse.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/response/ShinhanBankSearchSavingAccountResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.tott.api.shinhan.service.searchamount.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.tott.api.shinhan.dto.response.ShinhanBankAPIResponse;
+import com.ssafy.tott.api.shinhan.service.searchamount.dto.response.body.SearchSavingAccountResponseShinhanBankDataBody;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ShinhanBankSearchSavingAccountResponse extends ShinhanBankAPIResponse {
+    @JsonProperty("dataBody")
+    SearchSavingAccountResponseShinhanBankDataBody searchSavingAccountResponseShinhanBankDataBody;
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/response/body/SearchSavingAccountResponseShinhanBankDataBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchamount/dto/response/body/SearchSavingAccountResponseShinhanBankDataBody.java
@@ -1,0 +1,12 @@
+package com.ssafy.tott.api.shinhan.service.searchamount.dto.response.body;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.tott.api.shinhan.dto.ShinhanBankDataBody;
+
+public class SearchSavingAccountResponseShinhanBankDataBody extends ShinhanBankDataBody {
+    @JsonProperty("계좌번호")
+    private String accountNumber;
+
+    @JsonProperty("계좌잔액금액")
+    private String amount;
+}


### PR DESCRIPTION
# 개요
예적금 계좌 정보 가져오기 기능을 구현합니다.
예적금 계좌 조회 API를 활용하여 가져오고, 회원 가입 절차와 연동 예정입니다.
<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! --> 
resolved: #20 