### PR TITLE
예적금 계좌 구분 및 저장, 사용자 정보에 추가한다

### DIFF
--- a/src/main/java/com/ssafy/tott/account/service/AccountService.java
+++ b/src/main/java/com/ssafy/tott/account/service/AccountService.java
@@ -1,4 +1,42 @@
 package com.ssafy.tott.account.service;
 
+import com.ssafy.tott.account.domain.Account;
+import com.ssafy.tott.account.domain.AccountRepository;
+import com.ssafy.tott.account.domain.BankCode;
+import com.ssafy.tott.account.domain.embbeded.AccountNumber;
+import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
+import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.response.ShinhanBankSearchAccountsResponse;
+import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.response.body.ShinhanBankSearchAccountsResponseAccount;
+import com.ssafy.tott.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class AccountService {
+    private final AccountRepository accountRepository;
+    private final ShinhanBankAPI shinhanBankAPI;
+    private final PasswordEncoder passwordEncoder;
+
+    public void searchAccounts(Member member) {
+        // 이름 암호화
+        String encodedName = passwordEncoder.encode(member.getId() + member.getName());
+
+        ShinhanBankSearchAccountsResponse response = (ShinhanBankSearchAccountsResponse) shinhanBankAPI.fetchSearchAccountsAPI(encodedName);
+        List<ShinhanBankSearchAccountsResponseAccount> responseAccounts = response.getShinhanBankSearchAccountsResponseDataBody().getAccounts();
+        for (ShinhanBankSearchAccountsResponseAccount responseAccount : responseAccounts) {
+            accountRepository.save(Account.builder()
+                .accountNumber(AccountNumber.from(responseAccount.getAccountNumber()))
+                .amount(Long.parseLong(responseAccount.getAmount()))
+                .member(member)
+                .bankCode(BankCode.SHINHAN)
+                .build()
+            );
+        }
+    }
 }

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -57,7 +57,7 @@ public class ShinhanBankAPI {
         return response;
     }
 
-    public ShinhanBankAPIResponse searchAccountsAPI(String encodedName) {
+    public ShinhanBankAPIResponse fetchSearchAccountsAPI(String encodedName) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key,
                 ShinhanBankSearchAccountsRequestBody.from(encodedName)

--- a/src/main/java/com/ssafy/tott/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/tott/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.ssafy.tott.member.service;
 
 import com.ssafy.tott.account.domain.BankCode;
+import com.ssafy.tott.account.service.AccountService;
 import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.response.ShinhanBankSearchNameResponse;
 import com.ssafy.tott.api.shinhan.service.transfer1.dto.response.ShinhanBankTransfer1Response;
@@ -27,6 +28,7 @@ public class MemberService {
     private final MemberVerificationService memberVerificationService;
     private final ShinhanBankAPI shinhanBankAPI;
     private final MemberMapper mapper;
+    private final AccountService accountService;
 
     @Transactional
     public MemberSignupResponse signup(MemberSignupRequest request) {
@@ -48,6 +50,8 @@ public class MemberService {
         ShinhanBankSearchNameResponse responseAPI = (ShinhanBankSearchNameResponse) shinhanBankAPI.fetchSearchNameAPI(bankCode, accountNumber);
 
         Member savedMember = memberRepository.save(mapper.toMember(responseAPI, memberVerificationCache));
+
+        accountService.searchAccounts(savedMember);
         return MemberVerificationResponse.from(savedMember.getId());
     }
 


### PR DESCRIPTION
# 개요

전체 계좌를 조회하여 사용자가 현재 사용 가능한 금액을 보유하는 예적금 계좌를 구분합니다.
예적금 계좌를 DB에 저장한 후 사용자의 계좌 목록에 추가합니다.

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
<!-- example ) -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 한 일
 
- [x] 전체 계좌 중 예적금 계좌 구분 및 저장
- [x] 사용자 계좌 목록에 해당 계좌 추가

<!-- 한 일 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->