### PR TITLE
전세 대출 한도 조회 API 를 호출하는 기능을 구현한다

### DIFF
--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -9,7 +9,7 @@ import com.ssafy.tott.api.exception.APIException;
 import com.ssafy.tott.api.shinhan.dto.ShinhanBankDataBody;
 import com.ssafy.tott.api.shinhan.dto.request.ShinhanBankAPIRequest;
 import com.ssafy.tott.api.shinhan.dto.response.ShinhanBankAPIResponse;
-import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.ShinhanBankSearchAccountsFetchAPI;
+import com.ssafy.tott.api.shinhan.service.searchaccounts.ShinhanBankSearchAccountsFetchAPI;
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.request.ShinhanBankSearchAccountsRequest;
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.request.ShinhanBankSearchAccountsRequestBody;
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.response.ShinhanBankSearchAccountsResponse;

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -46,6 +46,9 @@ public class ShinhanBankAPI {
     @Value("${SHINHAN_BANK.API.KEY}")
     private String key;
 
+    @Value("${SHINHAN_BANK.API.SERVICE_KEY.SEARCH_CREDIT_LINE}")
+    private String serviceKey;
+
     public ShinhanBankSearchNameResponse fetchSearchNameAPI(BankCode bankCode, String account) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key, ShinhanBankSearchNameRequestDataBody.of(bankCode.getCode(), account));
@@ -84,11 +87,15 @@ public class ShinhanBankAPI {
     }
 
     public ShinhanBankSearchCreditLineResponse fetchSearchCreditLineAPI(
-            String serviceCode, String linkedTransactionInformation, String housingLocationCode, String rentGtn, String annualIncome
+            String linkedTransactionInformation, String housingLocationCode, String rentGtn, String annualIncome
     ) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key, ShinhanBankSearchCreditLineRequestBody.of(
-                        serviceCode, linkedTransactionInformation, housingLocationCode, rentGtn + "0000", annualIncome));
+                        serviceKey,
+                        "/Yqu0KRktzwFOQn2Yv//k254smViUMSf/0Z+z9XMIOFl8cv4OS3ZQHRIHufe61jEqLJNsOANugmvpVGpRwGdjg==",
+                        "04513",
+                        "500000000",
+                        "60000000"));
 
         logging(request.getShinhanBankDataBody());
 

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -91,11 +91,7 @@ public class ShinhanBankAPI {
     ) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key, ShinhanBankSearchCreditLineRequestBody.of(
-                        serviceKey,
-                        "/Yqu0KRktzwFOQn2Yv//k254smViUMSf/0Z+z9XMIOFl8cv4OS3ZQHRIHufe61jEqLJNsOANugmvpVGpRwGdjg==",
-                        "04513",
-                        "500000000",
-                        "60000000"));
+                        serviceKey, linkedTransactionInformation, housingLocationCode, rentGtn, annualIncome));
 
         logging(request.getShinhanBankDataBody());
 

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -13,6 +13,10 @@ import com.ssafy.tott.api.shinhan.service.searchaccounts.ShinhanBankSearchAccoun
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.request.ShinhanBankSearchAccountsRequest;
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.request.ShinhanBankSearchAccountsRequestBody;
 import com.ssafy.tott.api.shinhan.service.searchaccounts.dto.response.ShinhanBankSearchAccountsResponse;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.ShinhanBankSearchCreditLineFetchAPI;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request.ShinhanBankSearchCreditLineRequest;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request.ShinhanBankSearchCreditLineRequestBody;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
 import com.ssafy.tott.api.shinhan.service.searchname.ShinhanBankSearchNameFetchAPI;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.request.ShinhanBankSearchNameRequest;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.request.ShinhanBankSearchNameRequestDataBody;
@@ -36,6 +40,8 @@ public class ShinhanBankAPI {
     private final ShinhanBankTransfer1FetchAPI transfer1API;
     private final ShinhanBankSearchNameFetchAPI searchNameAPI;
     private final ShinhanBankSearchAccountsFetchAPI searchAccountsAPI;
+
+    private final ShinhanBankSearchCreditLineFetchAPI searchCreditLineFetchAPI;
 
     @Value("${SHINHAN_BANK.API.KEY}")
     private String key;
@@ -65,13 +71,29 @@ public class ShinhanBankAPI {
     }
 
     public ShinhanBankSearchAccountsResponse fetchSearchAccountsAPI(String encodedName) {
-        ShinhanBankAPIRequest shinhanBankAPIRequest =
+        ShinhanBankAPIRequest request =
                 ShinhanBankAPIRequest.of(key, ShinhanBankSearchAccountsRequestBody.from(encodedName));
 
-        logging(shinhanBankAPIRequest.getShinhanBankDataBody());
+        logging(request.getShinhanBankDataBody());
 
         ShinhanBankSearchAccountsResponse response = searchAccountsAPI.fetchAPI(
-                ShinhanBankSearchAccountsRequest.toRequest(convertRequestToJson(shinhanBankAPIRequest)));
+                ShinhanBankSearchAccountsRequest.toRequest(convertRequestToJson(request)));
+
+        validate(response);
+        return response;
+    }
+
+    public ShinhanBankSearchCreditLineResponse fetchSearchCreditLineAPI(
+            String serviceCode, String linkedTransactionInformation, String housingLocationCode, String rentGtn, String annualIncome
+    ) {
+        ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
+                key, ShinhanBankSearchCreditLineRequestBody.of(
+                        serviceCode, linkedTransactionInformation, housingLocationCode, rentGtn + "0000", annualIncome));
+
+        logging(request.getShinhanBankDataBody());
+
+        ShinhanBankSearchCreditLineResponse response = searchCreditLineFetchAPI.fetchAPI(
+                ShinhanBankSearchCreditLineRequest.toRequest(convertRequestToJson(request)));
 
         validate(response);
         return response;

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchaccounts/ShinhanBankSearchAccountsFetchAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchaccounts/ShinhanBankSearchAccountsFetchAPI.java
@@ -1,4 +1,4 @@
-package com.ssafy.tott.api.shinhan.service.searchaccounts.dto;
+package com.ssafy.tott.api.shinhan.service.searchaccounts;
 
 import com.ssafy.tott.api.core.FetchAPICore;
 import com.ssafy.tott.api.core.dto.APIRequest;

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/ShinhanBankSearchCreditLineFetchAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/ShinhanBankSearchCreditLineFetchAPI.java
@@ -1,0 +1,34 @@
+package com.ssafy.tott.api.shinhan.service.searchcreditline;
+
+import com.ssafy.tott.api.core.FetchAPICore;
+import com.ssafy.tott.api.core.dto.APIRequest;
+import com.ssafy.tott.api.shinhan.factory.ShinhanBankWebClientFactory;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request.ShinhanBankSearchCreditLineRequest;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Component
+public class ShinhanBankSearchCreditLineFetchAPI implements FetchAPICore {
+    private final ShinhanBankWebClientFactory shinhanBankWebClientFactory;
+
+    @Value("${SHINHAN_BANK.API.URI.SEARCH_CREDIT_LINE}")
+    private String uri;
+
+
+    @Override
+    public ShinhanBankSearchCreditLineResponse fetchAPI(APIRequest request) {
+        ShinhanBankSearchCreditLineRequest shinhanBankSearchCreditLineRequest =
+                (ShinhanBankSearchCreditLineRequest) request;
+        WebClient webClient = shinhanBankWebClientFactory.createWebClientWithURI(uri);
+        return webClient
+                .post()
+                .bodyValue(shinhanBankSearchCreditLineRequest.getJson())
+                .retrieve()
+                .bodyToMono(ShinhanBankSearchCreditLineResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequest.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequest.java
@@ -1,0 +1,18 @@
+package com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request;
+
+import com.ssafy.tott.api.core.dto.request.APIJsonRequest;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ShinhanBankSearchCreditLineRequest implements APIJsonRequest {
+    private String json;
+
+    public static ShinhanBankSearchCreditLineRequest toRequest(String json) {
+        return new ShinhanBankSearchCreditLineRequest(json);
+    }
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
@@ -1,0 +1,49 @@
+package com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ShinhanBankSearchCreditLineRequestBody {
+    @JsonProperty("serviceCode")
+    private String serviceCode;
+
+    @JsonProperty("연동거래정보")
+    private String linkedTransactionInformation;
+
+    @JsonProperty("주택소재지코드")
+    private String housingLocationCode;
+
+    @JsonProperty("보증금액")
+    private String rentGtn;
+
+    @JsonProperty("연소득")
+    private String annualIncome;
+
+    private ShinhanBankSearchCreditLineRequestBody(String serviceCode,
+                                                  String linkedTransactionInformation,
+                                                  String housingLocationCode,
+                                                  String rentGtn,
+                                                  String annualIncome) {
+        this.serviceCode = serviceCode;
+        this.linkedTransactionInformation = linkedTransactionInformation;
+        this.housingLocationCode = housingLocationCode;
+        this.rentGtn = rentGtn;
+        this.annualIncome = annualIncome;
+    }
+
+    public ShinhanBankSearchCreditLineRequestBody of(String serviceCode,
+                                                     String linkedTransactionInformation,
+                                                     String housingLocationCode,
+                                                     String rentGtn,
+                                                     String annualIncome) {
+        return new ShinhanBankSearchCreditLineRequestBody(serviceCode,
+                linkedTransactionInformation,
+                housingLocationCode,
+                rentGtn,
+                annualIncome);
+    }
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody {
-    @JsonProperty("serviceCode")
+    @JsonProperty()
     private String serviceCode;
 
     @JsonProperty("연동거래정보")
@@ -24,11 +24,12 @@ public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody 
     @JsonProperty("연소득")
     private String annualIncome;
 
-    private ShinhanBankSearchCreditLineRequestBody(String serviceCode,
-                                                  String linkedTransactionInformation,
-                                                  String housingLocationCode,
-                                                  String rentGtn,
-                                                  String annualIncome) {
+    private ShinhanBankSearchCreditLineRequestBody(
+            String serviceCode,
+            String linkedTransactionInformation,
+            String housingLocationCode,
+            String rentGtn,
+            String annualIncome) {
         this.serviceCode = serviceCode;
         this.linkedTransactionInformation = linkedTransactionInformation;
         this.housingLocationCode = housingLocationCode;
@@ -36,12 +37,14 @@ public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody 
         this.annualIncome = annualIncome;
     }
 
-    public static ShinhanBankSearchCreditLineRequestBody of(String serviceCode,
-                                                     String linkedTransactionInformation,
-                                                     String housingLocationCode,
-                                                     String rentGtn,
-                                                     String annualIncome) {
-        return new ShinhanBankSearchCreditLineRequestBody(serviceCode,
+    public static ShinhanBankSearchCreditLineRequestBody of(
+            String serviceCode,
+            String linkedTransactionInformation,
+            String housingLocationCode,
+            String rentGtn,
+            String annualIncome) {
+        return new ShinhanBankSearchCreditLineRequestBody(
+                serviceCode,
                 linkedTransactionInformation,
                 housingLocationCode,
                 rentGtn,

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
@@ -1,13 +1,14 @@
 package com.ssafy.tott.api.shinhan.service.searchcreditline.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.tott.api.shinhan.dto.ShinhanBankDataBody;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ShinhanBankSearchCreditLineRequestBody {
+public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody {
     @JsonProperty("serviceCode")
     private String serviceCode;
 
@@ -35,7 +36,7 @@ public class ShinhanBankSearchCreditLineRequestBody {
         this.annualIncome = annualIncome;
     }
 
-    public ShinhanBankSearchCreditLineRequestBody of(String serviceCode,
+    public static ShinhanBankSearchCreditLineRequestBody of(String serviceCode,
                                                      String linkedTransactionInformation,
                                                      String housingLocationCode,
                                                      String rentGtn,

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
@@ -1,0 +1,15 @@
+package com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ssafy.tott.api.shinhan.dto.response.ShinhanBankAPIResponse;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.body.ShinhanBankSearchCreditLineResponseDataBody;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ShinhanBankSearchCreditLineResponse extends ShinhanBankAPIResponse {
+    @JsonProperty("dataBody")
+    ShinhanBankSearchCreditLineResponseDataBody responseDataBody;
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/body/ShinhanBankSearchCreditLineResponseDataBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/body/ShinhanBankSearchCreditLineResponseDataBody.java
@@ -1,0 +1,13 @@
+package com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.body;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ShinhanBankSearchCreditLineResponseDataBody {
+    @JsonProperty("예상대출한도")
+    private String creditLine;
+}


### PR DESCRIPTION
# 개요

신한은행에서 제공하는 전세 대출 한도 조회 API 호출하는 기능을 구현한다

<!-- 개요에는 새로운 기능을 추가하면 좋을지에 대해서 알려주세요! -->
<!-- example ) 회원 가입을 하는데 아이디 중복 유무를 확인하는 기능이 있으면 좋겠습니다. -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 할 일

- API 호출 기능 구현
- 사용자의 `creditLine`에 조회한 데이터로 업데이트
- 처음 회원가입할 때 한번 실행 후 로그인할 때 마다 조회
    - (2023-09-12 수정) 사용자가 매물 한도를 설정할 때마다 대출 한도가 변경됨
    - (2023-09-12 수정) 회원가입마다 변경 적용 여부 의논 필요

<!-- 할 일 에서는 어떠한 작업을 해야하는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - 중복일 경우 예외 처리 기능 구현 -->
<!-- - ... -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 [](url) 가 생성되는데 -->
<!-- [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->

