### PR TITLE
보증금 설정을 통한 전세 대출 한도 설정 기능을 구현

### DIFF
--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -87,7 +87,7 @@ public class ShinhanBankAPI {
     }
 
     public ShinhanBankSearchCreditLineResponse fetchSearchCreditLineAPI(
-            String linkedTransactionInformation, String housingLocationCode, String rentGtn, String annualIncome
+            String linkedTransactionInformation, String housingLocationCode, int rentGtn, int annualIncome
     ) {
         ShinhanBankAPIRequest request = ShinhanBankAPIRequest.of(
                 key, ShinhanBankSearchCreditLineRequestBody.of(

--- a/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/ShinhanBankAPI.java
@@ -40,7 +40,6 @@ public class ShinhanBankAPI {
     private final ShinhanBankTransfer1FetchAPI transfer1API;
     private final ShinhanBankSearchNameFetchAPI searchNameAPI;
     private final ShinhanBankSearchAccountsFetchAPI searchAccountsAPI;
-
     private final ShinhanBankSearchCreditLineFetchAPI searchCreditLineFetchAPI;
 
     @Value("${SHINHAN_BANK.API.KEY}")
@@ -93,10 +92,12 @@ public class ShinhanBankAPI {
                 key, ShinhanBankSearchCreditLineRequestBody.of(
                         serviceKey, linkedTransactionInformation, housingLocationCode, rentGtn, annualIncome));
 
-        logging(request.getShinhanBankDataBody());
+
 
         ShinhanBankSearchCreditLineResponse response = searchCreditLineFetchAPI.fetchAPI(
                 ShinhanBankSearchCreditLineRequest.toRequest(convertRequestToJson(request)));
+
+        logging(request.getShinhanBankDataBody());
 
         validate(response);
         return response;

--- a/src/main/java/com/ssafy/tott/api/shinhan/controller/ShinhanBankController.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/controller/ShinhanBankController.java
@@ -2,6 +2,8 @@ package com.ssafy.tott.api.shinhan.controller;
 
 import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
 import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
+import com.ssafy.tott.auth.annotation.Authenticated;
+import com.ssafy.tott.auth.vo.AuthMember;
 import com.ssafy.tott.member.domain.Member;
 import com.ssafy.tott.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,9 @@ public class ShinhanBankController {
     MemberService memberService;
     @GetMapping("/searchCreditLine")
     public ResponseEntity<String> searchCreditLine(
-            @RequestParam int memberId, @RequestParam int houseGtn
+            @Authenticated AuthMember authMember, @RequestParam int houseGtn
     ) {
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findById(authMember.getMemberId());
 
         ShinhanBankSearchCreditLineResponse response = shinhanBankAPI.fetchSearchCreditLineAPI(
                 "/Yqu0KRktzwFOQn2Yv//k254smViUMSf/0Z+z9XMIOFl8cv4OS3ZQHRIHufe61jEqLJNsOANugmvpVGpRwGdjg==",

--- a/src/main/java/com/ssafy/tott/api/shinhan/controller/ShinhanBankController.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/controller/ShinhanBankController.java
@@ -1,0 +1,35 @@
+package com.ssafy.tott.api.shinhan.controller;
+
+import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
+import com.ssafy.tott.member.domain.Member;
+import com.ssafy.tott.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/shinhan")
+@RequiredArgsConstructor
+public class ShinhanBankController {
+    private final ShinhanBankAPI shinhanBankAPI;
+
+    MemberService memberService;
+    @GetMapping("/searchCreditLine")
+    public ResponseEntity<String> searchCreditLine(
+            @RequestParam int memberId, @RequestParam int houseGtn
+    ) {
+        Member member = memberService.findById(memberId);
+
+        ShinhanBankSearchCreditLineResponse response = shinhanBankAPI.fetchSearchCreditLineAPI(
+                "/Yqu0KRktzwFOQn2Yv//k254smViUMSf/0Z+z9XMIOFl8cv4OS3ZQHRIHufe61jEqLJNsOANugmvpVGpRwGdjg==",
+                "04513",
+                houseGtn,
+                member.getAnnualIncome());
+
+        return ResponseEntity.ok(response.getCreditLine());
+    }
+}

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
@@ -41,13 +41,13 @@ public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody 
             String serviceCode,
             String linkedTransactionInformation,
             String housingLocationCode,
-            String rentGtn,
-            String annualIncome) {
+            int rentGtn,
+            int annualIncome) {
         return new ShinhanBankSearchCreditLineRequestBody(
                 serviceCode,
                 linkedTransactionInformation,
                 housingLocationCode,
-                rentGtn,
-                annualIncome);
+                rentGtn + "0000",
+                annualIncome + "0000");
     }
 }

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/request/ShinhanBankSearchCreditLineRequestBody.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody {
-    @JsonProperty()
+    @JsonProperty
     private String serviceCode;
 
     @JsonProperty("연동거래정보")
@@ -47,7 +47,7 @@ public class ShinhanBankSearchCreditLineRequestBody extends ShinhanBankDataBody 
                 serviceCode,
                 linkedTransactionInformation,
                 housingLocationCode,
-                rentGtn + "0000",
-                annualIncome + "0000");
+                String.format("%d%s",rentGtn , "0000"),
+                String.format("%d%s",annualIncome, "0000"));
     }
 }

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
@@ -13,7 +13,7 @@ public class ShinhanBankSearchCreditLineResponse extends ShinhanBankAPIResponse 
     @JsonProperty("dataBody")
     ShinhanBankSearchCreditLineResponseDataBody responseDataBody;
 
-    public int getCreditLine() {
-        return Integer.parseInt(responseDataBody.getCreditLine());
+    public String getCreditLine() {
+        return responseDataBody.getCreditLine();
     }
 }

--- a/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
+++ b/src/main/java/com/ssafy/tott/api/shinhan/service/searchcreditline/dto/response/ShinhanBankSearchCreditLineResponse.java
@@ -12,4 +12,8 @@ import lombok.NoArgsConstructor;
 public class ShinhanBankSearchCreditLineResponse extends ShinhanBankAPIResponse {
     @JsonProperty("dataBody")
     ShinhanBankSearchCreditLineResponseDataBody responseDataBody;
+
+    public int getCreditLine() {
+        return Integer.parseInt(responseDataBody.getCreditLine());
+    }
 }

--- a/src/main/java/com/ssafy/tott/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/tott/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.ssafy.tott.auth.domain.AuthTokenRepository;
 import com.ssafy.tott.auth.dto.request.LoginRequest;
 import com.ssafy.tott.auth.dto.response.TokenResponse;
 import com.ssafy.tott.auth.support.TokenProvider;
+import com.ssafy.tott.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -17,6 +18,7 @@ public class AuthService {
     private final AuthTokenRepository authTokenRepository;
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final MemberService memberService;
 
     public TokenResponse login(LoginRequest request) {
         UsernamePasswordAuthenticationToken authentication = request.toAuthentication();
@@ -27,8 +29,10 @@ public class AuthService {
         int memberId = Integer.parseInt(authenticate.getName());
 
         AuthToken token = AuthToken.builder().id(memberId).value(response.getRefreshToken()).build();
-
         authTokenRepository.save(token);
+
+        memberService.updateCreditLine(memberId);
+
         return response;
     }
 }

--- a/src/main/java/com/ssafy/tott/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/tott/auth/service/AuthService.java
@@ -5,7 +5,6 @@ import com.ssafy.tott.auth.domain.AuthTokenRepository;
 import com.ssafy.tott.auth.dto.request.LoginRequest;
 import com.ssafy.tott.auth.dto.response.TokenResponse;
 import com.ssafy.tott.auth.support.TokenProvider;
-import com.ssafy.tott.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -18,7 +17,6 @@ public class AuthService {
     private final AuthTokenRepository authTokenRepository;
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final MemberService memberService;
 
     public TokenResponse login(LoginRequest request) {
         UsernamePasswordAuthenticationToken authentication = request.toAuthentication();
@@ -30,9 +28,6 @@ public class AuthService {
 
         AuthToken token = AuthToken.builder().id(memberId).value(response.getRefreshToken()).build();
         authTokenRepository.save(token);
-
-        memberService.updateCreditLine(memberId);
-
         return response;
     }
 }

--- a/src/main/java/com/ssafy/tott/budget/controller/BudgetController.java
+++ b/src/main/java/com/ssafy/tott/budget/controller/BudgetController.java
@@ -18,8 +18,9 @@ public class BudgetController {
     @PostMapping("/save")
     public ResponseEntity<BudgetsResponse> saveAll(
             @Authenticated AuthMember authMember,
-            @RequestBody BudgetsUpdateRequest budgetsUpdateRequest) {
-        BudgetsResponse response = budgetService.saveAll(authMember, budgetsUpdateRequest);
+            @RequestBody BudgetsUpdateRequest budgetsUpdateRequest,
+            @RequestParam int annualIncome) {
+        BudgetsResponse response = budgetService.saveAll(authMember, budgetsUpdateRequest, annualIncome);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/ssafy/tott/budget/service/BudgetService.java
+++ b/src/main/java/com/ssafy/tott/budget/service/BudgetService.java
@@ -24,7 +24,7 @@ public class BudgetService {
     private final MemberService memberService;
 
     @Transactional
-    public BudgetsResponse saveAll(AuthMember authMember, BudgetsUpdateRequest request) {
+    public BudgetsResponse saveAll(AuthMember authMember, BudgetsUpdateRequest request, int annualIncome) {
         Member member = memberService.findById(authMember.getMemberId());
 
         member.removeBudgets();
@@ -33,6 +33,8 @@ public class BudgetService {
         List<Budget> budgets = toBudgets(member, request);
 
         List<Budget> savedBudgets = budgetRepository.saveAll(budgets);
+        memberService.updateAnnualIncome(member, annualIncome);
+
         return new BudgetsResponse(
                 savedBudgets.stream().map(BudgetVO::from).collect(Collectors.toList()));
     }

--- a/src/main/java/com/ssafy/tott/member/controller/MemberController.java
+++ b/src/main/java/com/ssafy/tott/member/controller/MemberController.java
@@ -8,10 +8,7 @@ import com.ssafy.tott.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/member")
 @RequiredArgsConstructor

--- a/src/main/java/com/ssafy/tott/member/domain/Member.java
+++ b/src/main/java/com/ssafy/tott/member/domain/Member.java
@@ -37,7 +37,11 @@ public class Member extends BaseEntity {
     @Embedded
     private PhoneNumber phoneNumber;
 
-    private Long creditLine;
+    private int annualIncome;
+
+    private int maxHouseGtn;
+
+    private int creditLine;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -57,14 +61,12 @@ public class Member extends BaseEntity {
             String name,
             Email email,
             Password password,
-            PhoneNumber phoneNumber,
-            Long creditLine) {
+            PhoneNumber phoneNumber) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.password = password;
         this.phoneNumber = phoneNumber;
-        this.creditLine = creditLine;
         role = Role.USER;
     }
 
@@ -78,6 +80,18 @@ public class Member extends BaseEntity {
 
     public String getEncryptedPassword() {
         return password.getValue();
+    }
+
+    public void updateAnnualIncome(int annualIncome) {
+        this.annualIncome = annualIncome;
+    }
+
+    public void updateMaxHouseGtn(int maxHouseGtn) {
+        this.maxHouseGtn = maxHouseGtn;
+    }
+
+    public void updateCreditLine(int creditLine) {
+        this.creditLine = creditLine;
     }
 
     public void removeBudgets() {

--- a/src/main/java/com/ssafy/tott/member/domain/Member.java
+++ b/src/main/java/com/ssafy/tott/member/domain/Member.java
@@ -41,8 +41,6 @@ public class Member extends BaseEntity {
 
     private int maxHouseGtn;
 
-    private int creditLine;
-
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -88,10 +86,6 @@ public class Member extends BaseEntity {
 
     public void updateMaxHouseGtn(int maxHouseGtn) {
         this.maxHouseGtn = maxHouseGtn;
-    }
-
-    public void updateCreditLine(int creditLine) {
-        this.creditLine = creditLine;
     }
 
     public void removeBudgets() {

--- a/src/main/java/com/ssafy/tott/member/mapper/MemberMapper.java
+++ b/src/main/java/com/ssafy/tott/member/mapper/MemberMapper.java
@@ -23,7 +23,6 @@ public class MemberMapper {
                 .email(memberVerificationCache.getEmail())
                 .password(memberVerificationCache.getPassword())
                 .phoneNumber(memberVerificationCache.getPhoneNumber())
-                .creditLine(0L)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/tott/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/tott/member/service/MemberService.java
@@ -3,7 +3,6 @@ package com.ssafy.tott.member.service;
 import com.ssafy.tott.account.domain.BankCode;
 import com.ssafy.tott.account.service.AccountService;
 import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
-import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.response.ShinhanBankSearchNameResponse;
 import com.ssafy.tott.api.shinhan.service.transfer1.dto.response.ShinhanBankTransfer1Response;
 import com.ssafy.tott.api.shinhan.service.transfer1.dto.response.body.Transfer1ResponseShinhanBankDataBody;
@@ -57,33 +56,6 @@ public class MemberService {
 
         accountService.searchAccounts(savedMember);
         return MemberVerificationResponse.from(savedMember.getId());
-    }
-
-    @Transactional
-    public void updateCreditLine(int memberId) {
-        Member member = findById(memberId);
-
-        if (canCreditLineReset(member)) {
-            return;
-        }
-        member.updateCreditLine(searchCreditLine(member));
-    }
-
-    private boolean canCreditLineReset(Member member) {
-        if (member.getAnnualIncome() == 0 || member.getMaxHouseGtn() == 0){
-            member.updateCreditLine(0);
-            return false;
-        }
-        return true;
-    }
-
-    private int searchCreditLine(Member member) {
-        ShinhanBankSearchCreditLineResponse response = shinhanBankAPI.fetchSearchCreditLineAPI(
-                "1",
-                "04513",
-                member.getMaxHouseGtn(),
-                member.getAnnualIncome());
-        return response.getCreditLine();
     }
 
     @Transactional

--- a/src/main/java/com/ssafy/tott/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/tott/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.ssafy.tott.member.service;
 import com.ssafy.tott.account.domain.BankCode;
 import com.ssafy.tott.account.service.AccountService;
 import com.ssafy.tott.api.shinhan.ShinhanBankAPI;
+import com.ssafy.tott.api.shinhan.service.searchcreditline.dto.response.ShinhanBankSearchCreditLineResponse;
 import com.ssafy.tott.api.shinhan.service.searchname.dto.response.ShinhanBankSearchNameResponse;
 import com.ssafy.tott.api.shinhan.service.transfer1.dto.response.ShinhanBankTransfer1Response;
 import com.ssafy.tott.api.shinhan.service.transfer1.dto.response.body.Transfer1ResponseShinhanBankDataBody;
@@ -56,6 +57,33 @@ public class MemberService {
 
         accountService.searchAccounts(savedMember);
         return MemberVerificationResponse.from(savedMember.getId());
+    }
+
+    @Transactional
+    public void updateCreditLine(int memberId) {
+        Member member = findById(memberId);
+
+        if (canCreditLineReset(member)) {
+            return;
+        }
+        member.updateCreditLine(searchCreditLine(member));
+    }
+
+    private boolean canCreditLineReset(Member member) {
+        if (member.getAnnualIncome() == 0 || member.getMaxHouseGtn() == 0){
+            member.updateCreditLine(0);
+            return false;
+        }
+        return true;
+    }
+
+    private int searchCreditLine(Member member) {
+        ShinhanBankSearchCreditLineResponse response = shinhanBankAPI.fetchSearchCreditLineAPI(
+                "1",
+                "04513",
+                member.getMaxHouseGtn(),
+                member.getAnnualIncome());
+        return response.getCreditLine();
     }
 
     public Member findById(int id) {

--- a/src/main/java/com/ssafy/tott/member/service/MemberService.java
+++ b/src/main/java/com/ssafy/tott/member/service/MemberService.java
@@ -86,6 +86,11 @@ public class MemberService {
         return response.getCreditLine();
     }
 
+    @Transactional
+    public void updateAnnualIncome(Member member, int annualIncome) {
+        member.updateAnnualIncome(annualIncome);
+    }
+
     public Member findById(int id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.ERROR_CLIENT_WITH_MEMBER_IS_NOT_EXISTED));


### PR DESCRIPTION
# 개요
보증금 설정을 통한 전세 대출 한도 설정 기능을 구현합니다.
<!-- 개요에는 새로운 기능을 추가하면 좋을지에 대해서 알려주세요! -->
<!-- example ) 회원 가입을 하는데 아이디 중복 유무를 확인하는 기능이 있으면 좋겠습니다. -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

## 할 일

- [x] 추가 자산 입력 처리 단계에서 연수입 입력 처리도 가능하도록 추가한다.
- [x] 매물 금액 설정 마다 전세 대출 한도가 조회되도록 한다.
- [x] 로그인 시 전세 대출 한도가 업데이트되도록 설정한다.

<!-- 할 일 에서는 어떠한 작업을 해야하는지 상세히 적어주세요! -->
<!-- example ) -->
<!-- - 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - 중복일 경우 예외 처리 기능 구현 -->
<!-- - ... -->

## ETC

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 -->
<!-- [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을 입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->